### PR TITLE
update go to version 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clink-n-Clank/Eitri
 
-go 1.17
+go 1.18
 
 require (
 	github.com/spf13/cobra v1.4.0


### PR DESCRIPTION
Upgrading go version from 1.17 to 1.18